### PR TITLE
[FIX] show_io_stat has diff operator make it crash

### DIFF
--- a/src/btop_draw.cpp
+++ b/src/btop_draw.cpp
@@ -970,7 +970,7 @@ namespace Mem {
 						out += Mv::to(y + 1 + cy, x + 1 + cx) + (big_disk ? " Used:" + rjust(to_string(disk.used_percent) + '%', 4) : "U") + ' '
 							+ disk_meters_used.at(mount)(disk.used_percent) + rjust(human_used, (big_disk ? 9 : 5));
 						cy++;
-						if (cmp_less_equal(disks.size() * 4 + (show_io_stat ? disk_ios : 0), height - 1)) cy++;
+						if (cmp_less_equal(disks.size() * 4 + disk_ios, height - 1)) cy++;
 					}
 
 				}

--- a/src/btop_draw.cpp
+++ b/src/btop_draw.cpp
@@ -966,7 +966,7 @@ namespace Mem {
 						+ disk_meters_free.at(mount)(disk.free_percent) + rjust(human_free, (big_disk ? 9 : 5));
 					if (++cy > height - 3) break;
 
-					if (cmp_less_equal(disks.size() * 3 + (show_io_stat ? disk_ios : 0), height - 1)) {
+					if (show_io_stat and cmp_less_equal(disks.size() * 3 + disk_ios, height - 1)) {
 						out += Mv::to(y + 1 + cy, x + 1 + cx) + (big_disk ? " Used:" + rjust(to_string(disk.used_percent) + '%', 4) : "U") + ' '
 							+ disk_meters_used.at(mount)(disk.used_percent) + rjust(human_used, (big_disk ? 9 : 5));
 						cy++;


### PR DESCRIPTION
# Summary
This pull request makes a targeted improvement to the disk usage display logic in `src/btop_draw.cpp`. The key change is to ensure that the display of I/O statistics is correctly gated by the `show_io_stat` flag, thereby avoiding null access exceptions caused by attempting to output I/O data when the feature is not enabled.

# Problem
fix #48 

## Bug Description
Setting `show_io_stat = False` in the configuration can cause the application to crash with the following exception:
`Exception in runner thread -> Mem:: -> key not found`

## Root Cause Analysis
The crash is caused by a condition mismatch between the initialization and rendering phases of the disk meters (`disk_meters_used`) in `src/btop_draw.cpp`.

**1. Initialization Phase (The Flaw)**
In `src/btop_draw.cpp` (around line 829):
```cpp
bool big_d = show_io_stat and cmp_less_equal(mem.disks.size() * 3 + disk_ios, height - 1);
if (big_d) disk_meters_used[name] = Draw::Meter{disk_meter, "used"};
```
When `show_io_stat` is `False`, the `big_d` evaluation short-circuits to `False`. As a result, the `Draw::Meter` object is **never created** and added to the `disk_meters_used` map.

**2. Rendering Phase (The Crash)**
In `src/btop_draw.cpp` (around line 969):
```cpp
if (cmp_less_equal(disks.size() * 3 + (show_io_stat ? disk_ios : 0), height - 1)) {
    out += Mv::to(y + 1 + cy, x + 1 + cx) + ... 
        + disk_meters_used.at(mount)(disk.used_percent) ...
}
```
During rendering, the code checks if there is enough vertical space to draw the basic disk meters (treating `disk_ios` as `0` since `show_io_stat` is `False`). If the terminal height is sufficient, this condition evaluates to `True`.

The code then executes `disk_meters_used.at(mount)`. Because the map was never populated during initialization, it throws a `std::out_of_range` ("key not found") exception, crashing the Mem thread.

# Proposed Solution
Align the initialization condition with the rendering condition, ensuring that `disk_meters_used` is always properly initialized whenever the rendering logic expects to draw it.

**Change in `src/btop_draw.cpp`:**
```cpp
// Before
if (cmp_less_equal(disks.size() * 3 + (show_io_stat ? disk_ios : 0), height - 1)) {
	out += Mv::to(y + 1 + cy, x + 1 + cx) + (big_disk ? " Used:" + rjust(to_string(disk.used_percent) + '%', 4) : "U") + ' '
		+ disk_meters_used.at(mount)(disk.used_percent) + rjust(human_used, (big_disk ? 9 : 5));
	cy++;
	if (cmp_less_equal(disks.size() * 4 + (show_io_stat ? disk_ios : 0), height - 1)) cy++;
}

// After
if (show_io_stat and cmp_less_equal(disks.size() * 3 + disk_ios, height - 1)) {
	out += Mv::to(y + 1 + cy, x + 1 + cx) + (big_disk ? " Used:" + rjust(to_string(disk.used_percent) + '%', 4) : "U") + ' '
		+ disk_meters_used.at(mount)(disk.used_percent) + rjust(human_used, (big_disk ? 9 : 5));
	cy++;
	if (cmp_less_equal(disks.size() * 4 + disk_ios, height - 1)) cy++;
}
```